### PR TITLE
fix: clarify task-executor autonomy and prevent redundant confirmations

### DIFF
--- a/.claude/agents/task-executor.md
+++ b/.claude/agents/task-executor.md
@@ -14,6 +14,11 @@ tools: Read, Edit, Write, MultiEdit, Bash, Task, Grep, Glob, LS
   ⚠️ **例外**: 品質保証工程（Phase1-6）・コミット作成は責務範囲外のため適用しない
 - @docs/rules/typescript-testing.md - テストルール
 
+## 重要：実装権限
+- task-executorが呼び出された時点で、実装は承認済み
+- CLAUDE.mdの「調査OK・実装STOP」ルールは適用外
+- 確認不要で即座に実装を実行
+
 ## 主な責務
 
 1. **タスク実行**
@@ -40,6 +45,7 @@ ls docs/plans/tasks/*.md | grep -E "task-[0-9]{2}\.md$" | head -1
 - 影響範囲と共通化ポイントの把握
 
 ### 3. 実装実行
+- 全チェックボックスが`[x]`の場合は「既に完了」と報告して終了
 - 段階的実装と逐次確認
 - 各ステップ完了時に3箇所同期更新
 - 追加したテストのみを実行して通ることを確認（全体テストは不要）

--- a/docs/sub-agents-guide.md
+++ b/docs/sub-agents-guide.md
@@ -183,6 +183,11 @@ Task(
 )
 ```
 
+### task-executorへの指示方法
+- タスクファイルパスのみ指定：「docs/plans/tasks/task-01.mdを実装してください」
+- 詳細な要件説明は不要（task-executorが計画書から読み取る）
+- **重要**: 完了済みタスクを渡しても実害なし（空振りで終了）
+
 ## 🔄 要件変更への対応パターン
 
 ### requirement-analyzerでの要件変更対応


### PR DESCRIPTION
- Add explicit implementation authority section to task-executor.md
- Clarify that task-executor operates without needing approval once invoked
- Add completion check to prevent re-execution of completed tasks
- Improve task-executor invocation instructions in sub-agents-guide.md
- Note that completed task re-execution is harmless (no-op behavior)

This fixes the issue where task-executor was repeatedly asking for confirmation instead of executing tasks autonomously.

🤖 Generated with [Claude Code](https://claude.ai/code)