### PR TITLE
docs: fix language setup wording in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,9 +60,9 @@ cd my-project
 # 依存関係のインストール
 npm install
 
-# 英語を希望する場合のみ切り替え（デフォルトは日本語）
-npm run lang:en    # 英語に切り替える場合
-# npm run lang:ja  # すでに日本語に設定済み
+# 使用する言語を設定（日本語版のプロジェクトとして設定）
+npm run lang:ja    # 日本語版として設定
+# npm run lang:en  # 英語版として設定する場合
 
 # Git履歴をリセットして新しいプロジェクトとして開始
 rm -rf .git

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ cd my-project
 # Install dependencies
 npm install
 
-# Switch to English if preferred (Japanese is set by default)
-npm run lang:en    # Switch to English
-# npm run lang:ja  # Already set to Japanese by default
+# Set up your project language (configure as English project)
+npm run lang:en    # Set up as English project
+# npm run lang:ja  # Set up as Japanese project if preferred
 
 # Reset Git history and start as a new project
 rm -rf .git


### PR DESCRIPTION
- Change 'switch' to 'set up' to reflect initial state
- Remove incorrect 'default' language concept
- Clarify that language needs to be configured after cloning

🤖 Generated with [Claude Code](https://claude.ai/code)