### PR TITLE
fix: Clarify orchestrator's commit execution responsibility in sub-agents guide

### DIFF
--- a/docs/guides/en/sub-agents.md
+++ b/docs/guides/en/sub-agents.md
@@ -211,7 +211,7 @@ graph TD
     TD --> LOOP[Task execution loop]
     LOOP --> TE[task-executor: Implementation]
     TE --> QF[quality-fixer: Quality check and fixes]
-    QF --> COMMIT[Create commit]
+    QF --> COMMIT[Me: Execute git commit]
     COMMIT --> CHECK{Any remaining tasks?}
     CHECK -->|Yes| LOOP
     CHECK -->|No| REPORT[Completion report]
@@ -247,9 +247,9 @@ Stop autonomous execution and escalate to user in the following cases:
    - Direct stop instruction or interruption
 
 ### Quality Assurance During Autonomous Execution
-- Automatically execute `task-executor → quality-fixer → commit` cycle for each task
-- Have quality-fixer handle all quality checks and fixes in completely self-contained manner
-- Maintain quality standards until all tasks are complete
+- Execute task-executor → Execute quality-fixer → **I execute commit** (using Bash tool)
+- After confirming quality-fixer's `approved: true`, immediately execute git commit
+- Use changeSummary for commit message
 
 ## 🎼 My Main Roles as Orchestrator
 
@@ -257,9 +257,9 @@ Stop autonomous execution and escalate to user in the following cases:
 2. **Information Bridging**: Data conversion and transmission between subagents
    - Convert each subagent's output to next subagent's input format
    - Extract necessary information from structured responses
-   - Compose commit messages from changeSummary
+   - Compose commit messages from changeSummary → **Execute git commit with Bash**
    - Explicitly integrate initial and additional requirements when requirements change
-3. **Quality Assurance**: Manage task → quality-check → commit cycle
+3. **Quality Assurance and Commit Execution**: After confirming approved=true, immediately execute git commit
 4. **Autonomous Execution Mode Management**: Start/stop autonomous execution after approval, escalation decisions
 5. **ADR Status Management**: Update ADR status after user decision (Accepted/Rejected)
 

--- a/docs/guides/ja/sub-agents.md
+++ b/docs/guides/ja/sub-agents.md
@@ -193,7 +193,7 @@ graph TD
     TD --> LOOP[タスク実行ループ]
     LOOP --> TE[task-executor: 実装]
     TE --> QF[quality-fixer: 品質チェック・修正]
-    QF --> COMMIT[コミット作成]
+    QF --> COMMIT[私: git commit実行]
     COMMIT --> CHECK{残りタスクあり?}
     CHECK -->|Yes| LOOP
     CHECK -->|No| REPORT[完了報告]
@@ -229,9 +229,9 @@ graph TD
    - 直接的な停止指示や割り込み
 
 ### 自律実行中の品質保証
-- 各タスクごとに`task-executor → quality-fixer → commit`サイクルを自動実行
-- quality-fixerに全品質チェックと修正を完全自己完結で処理させる
-- 全タスク完了まで品質基準を維持
+- task-executor実行 → quality-fixer実行 → **私がコミット実行**（Bashツール使用）
+- quality-fixerの`approved: true`確認後、即座にgit commitを実行
+- changeSummaryをコミットメッセージに使用
 
 ## 🎼 私のオーケストレーターとしての主な役割
 
@@ -239,9 +239,9 @@ graph TD
 2. **情報の橋渡し**: サブエージェント間のデータ変換と伝達
    - 各Sub-agentの出力を次のSub-agentの入力形式に変換
    - 構造化レスポンスから必要な情報を抽出
-   - changeSummaryからコミットメッセージを構成
+   - changeSummaryからコミットメッセージ構成→**Bashでgit commit実行**
    - 要件変更時は初回要件と追加要件を明示的に統合
-3. **品質保証**: task → quality-check → commit サイクルの管理  
+3. **品質保証とコミット実行**: approved=true確認後、即座にgit commit実行  
 4. **自律実行モード管理**: 承認後の自律実行開始・停止・エスカレーション判断
 5. **ADRステータス管理**: ユーザー判断後のADRステータス更新（Accepted/Rejected）
 


### PR DESCRIPTION
This PR clarifies the orchestrator's (Claude/Me) responsibility for executing
  git commits during autonomous execution mode in the sub-agents documentation.
  The changes ensure explicit and minimal descriptions that work reliably
  regardless of context capacity.

  ## Changes
  - 📝 Updated both Japanese (`docs/guides/ja/sub-agents.md`) and English
  (`docs/guides/en/sub-agents.md`) versions
  - 🎯 Explicitly stated "Me/私" as the commit execution entity in the Mermaid
  diagram
  - ✅ Clarified immediate git commit execution after quality-fixer approval
  - 🔧 Added explicit mention of using the Bash tool for commit execution
  - 📊 Removed redundant descriptions to optimize for clarity and precision

  ## Background
  Applied changes from commit 3086fb16 to ensure the orchestrator's role in
  commit execution is unambiguous. This prevents confusion about who executes
  commits during the autonomous execution cycle.