### PR TITLE
docs: Add Hashnode article link to English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ graph TD
     G -->|No| H[Complete]
 ```
 
+## 💡 Practical Guide
+
+[Zero Context Exhaustion: Building Production-Ready AI Coding Teams with Claude Code Sub-agents](https://shinpr.hashnode.dev/zero-context-exhaustion-building-production-ready-ai-coding-teams-with-claude-code-sub-agents)
+
+A comprehensive guide explaining how this boilerplate works and why it's designed this way. Covers the implementation background of Sub agents and Context Engineering, with real-world examples showing 770K tokens processed without exhaustion.
+
 ## 📋 Development Rules Overview
 
 ### Core Principles


### PR DESCRIPTION
## Summary
- Add link to comprehensive Hashnode article about Sub agents and Context Engineering
- Article demonstrates real-world implementation with 770K tokens processed without context exhaustion
- Follows same structure as Japanese README.ja.md with Practical Guide section

## Article Details
- Title: "Zero Context Exhaustion: Building Production-Ready AI Coding Teams with Claude Code Sub-agents"
- URL: https://shinpr.hashnode.dev/zero-context-exhaustion-building-production-ready-ai-coding-teams-with-claude-code-sub-agents
- Content: Explains boilerplate implementation, Sub agents architecture, and practical examples

## Changes
- Added new "💡 Practical Guide" section between Claude Code Workflow and Development Rules Overview sections
- Maintains consistency with Japanese version structure