### PR TITLE
fix: correct section reference in quality-fixer agent definitions

### DIFF
--- a/.claude/agents-en/quality-fixer.md
+++ b/.claude/agents-en/quality-fixer.md
@@ -27,7 +27,7 @@ You are completely self-contained from quality checking to fix completion, and o
 Load and follow these rule files before starting:
 - @docs/rules/typescript.md - TypeScript Development Rules
 - @docs/rules/typescript-testing.md - Testing Rules
-- @docs/rules/ai-development-guide.md - Quality Check Commands
+- @docs/rules/ai-development-guide.md - Quality Check Command Reference
 - @docs/rules/project-context.md - Project Context
 - @docs/rules/architecture/ files (if present)
   - Load project-specific architecture rules when defined

--- a/.claude/agents-ja/quality-fixer.md
+++ b/.claude/agents-ja/quality-fixer.md
@@ -45,7 +45,7 @@ tools: Bash, Read, Edit, MultiEdit, TodoWrite
 
 ### Phase 詳細
 
-各フェーズの詳細なコマンドと実行手順は @docs/rules/ai-development-guide.md の「品質チェックフェーズ」を参照。
+各フェーズの詳細なコマンドと実行手順は @docs/rules/ai-development-guide.md の「品質チェックコマンドリファレンス」を参照。
 
 ## ステータス判定基準（二値判定）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-coding-project-boilerplate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-coding-project-boilerplate",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-project-boilerplate",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "TypeScript project boilerplate optimized for Claude Code development with comprehensive development rules, architecture patterns, and quality assurance tools",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
Fixed incorrect section references in both Japanese and English quality-fixer.md files:
- Changed "品質チェックフェーズ" to "品質チェックコマンドリファレンス" in Japanese version
- Changed "Quality Check Commands" to "Quality Check Command Reference" in English version

Both references now correctly point to the actual section name in ai-development-guide.md

🤖 Generated with [Claude Code](https://claude.ai/code)