### PR TITLE
fix: resolve mermaid diagram syntax errors and update article link

### DIFF
--- a/docs/guides/en/quickstart.md
+++ b/docs/guides/en/quickstart.md
@@ -86,7 +86,7 @@ Instead of one AI trying to handle everything, specialized sub-agents handle spe
 
 This approach prevents context overflow and maintains quality even for large projects.
 
-For technical details, see [this article](https://qiita.com/shinpr/items/98771c2b8d2e15cafcd5).
+For technical details, see [this article](https://dev.to/shinpr/zero-context-exhaustion-building-production-ready-ai-coding-teams-with-claude-code-sub-agents-31b).
 
 ## Troubleshooting
 

--- a/docs/guides/en/use-cases.md
+++ b/docs/guides/en/use-cases.md
@@ -18,24 +18,24 @@ New to this? Start with the [Quick Start Guide](./quickstart.md). This is your d
 graph LR
     A[Requirements] --> B[Scale Detection]
     B -->|Small:1-2 files| C[Direct Implementation]
-    B -->|Medium:3-5 files| D[Design Doc<br>→Implementation]
-    B -->|Large:6+ files| E[PRD→ADR<br>→Design Doc<br>→Implementation]
+    B -->|Medium:3-5 files| D[Design Doc→Implementation]
+    B -->|Large:6+ files| E[PRD→ADR→Design Doc→Implementation]
 ```
 
 ## Inside /implement Command
 
 ```mermaid
 graph TD
-    Start[/implement requirements] --> RA[requirement-analyzer<br>scale detection]
+    Start[/implement requirements] --> RA[requirement-analyzer scale detection]
     RA -->|Small| Direct[Direct implementation]
-    RA -->|Medium| TD[technical-designer<br>Design Doc]
-    RA -->|Large| PRD[prd-creator<br>PRD]
+    RA -->|Medium| TD[technical-designer Design Doc]
+    RA -->|Large| PRD[prd-creator PRD]
     
-    PRD --> ADR[technical-designer<br>ADR]
+    PRD --> ADR[technical-designer ADR]
     ADR --> TD
-    TD --> WP[work-planner<br>Work plan]
-    WP --> TE[task-executor<br>Execute tasks]
-    Direct --> QF[quality-fixer<br>Quality checks]
+    TD --> WP[work-planner Work plan]
+    WP --> TE[task-executor Execute tasks]
+    Direct --> QF[quality-fixer Quality checks]
     TE --> QF
     QF --> End[Complete]
     

--- a/docs/guides/ja/use-cases.md
+++ b/docs/guides/ja/use-cases.md
@@ -18,24 +18,24 @@
 graph LR
     A[要件] --> B[規模判定]
     B -->|小:1-2ファイル| C[実装のみ]
-    B -->|中:3-5ファイル| D[Design Doc<br>→実装]
-    B -->|大:6ファイル以上| E[PRD→ADR<br>→Design Doc<br>→実装]
+    B -->|中:3-5ファイル| D[Design Doc→実装]
+    B -->|大:6ファイル以上| E[PRD→ADR→Design Doc→実装]
 ```
 
 ## /implementコマンドの裏側
 
 ```mermaid
 graph TD
-    Start[/implement 要件] --> RA[requirement-analyzer<br>規模判定]
+    Start[/implement 要件] --> RA[requirement-analyzer 規模判定]
     RA -->|小規模| Direct[直接実装]
-    RA -->|中規模| TD[technical-designer<br>Design Doc作成]
-    RA -->|大規模| PRD[prd-creator<br>PRD作成]
+    RA -->|中規模| TD[technical-designer Design Doc作成]
+    RA -->|大規模| PRD[prd-creator PRD作成]
     
-    PRD --> ADR[technical-designer<br>ADR作成]
+    PRD --> ADR[technical-designer ADR作成]
     ADR --> TD
-    TD --> WP[work-planner<br>作業計画書]
-    WP --> TE[task-executor<br>タスク実行]
-    Direct --> QF[quality-fixer<br>品質チェック]
+    TD --> WP[work-planner 作業計画書]
+    WP --> TE[task-executor タスク実行]
+    Direct --> QF[quality-fixer 品質チェック]
     TE --> QF
     QF --> End[完了]
     


### PR DESCRIPTION
- Remove HTML <br> tags from mermaid diagrams in use-cases.md (both ja/en)
- Replace Japanese Qiita link with English dev.to article in quickstart.md
- Fix lexical errors preventing proper mermaid diagram rendering

🤖 Generated with [Claude Code](https://claude.ai/code)