### PR TITLE
fix: wrap mermaid node labels with quotes to handle hyphens

### DIFF
--- a/docs/guides/en/use-cases.md
+++ b/docs/guides/en/use-cases.md
@@ -26,16 +26,16 @@ graph LR
 
 ```mermaid
 graph TD
-    Start[/implement requirements] --> RA[requirement-analyzer scale detection]
+    Start[/implement requirements] --> RA["requirement-analyzer scale detection"]
     RA -->|Small| Direct[Direct implementation]
-    RA -->|Medium| TD[technical-designer Design Doc]
-    RA -->|Large| PRD[prd-creator PRD]
+    RA -->|Medium| TD["technical-designer Design Doc"]
+    RA -->|Large| PRD["prd-creator PRD"]
     
-    PRD --> ADR[technical-designer ADR]
+    PRD --> ADR["technical-designer ADR"]
     ADR --> TD
-    TD --> WP[work-planner Work plan]
-    WP --> TE[task-executor Execute tasks]
-    Direct --> QF[quality-fixer Quality checks]
+    TD --> WP["work-planner Work plan"]
+    WP --> TE["task-executor Execute tasks"]
+    Direct --> QF["quality-fixer Quality checks"]
     TE --> QF
     QF --> End[Complete]
     

--- a/docs/guides/ja/use-cases.md
+++ b/docs/guides/ja/use-cases.md
@@ -26,16 +26,16 @@ graph LR
 
 ```mermaid
 graph TD
-    Start[/implement 要件] --> RA[requirement-analyzer 規模判定]
+    Start[/implement 要件] --> RA["requirement-analyzer 規模判定"]
     RA -->|小規模| Direct[直接実装]
-    RA -->|中規模| TD[technical-designer Design Doc作成]
-    RA -->|大規模| PRD[prd-creator PRD作成]
+    RA -->|中規模| TD["technical-designer Design Doc作成"]
+    RA -->|大規模| PRD["prd-creator PRD作成"]
     
-    PRD --> ADR[technical-designer ADR作成]
+    PRD --> ADR["technical-designer ADR作成"]
     ADR --> TD
-    TD --> WP[work-planner 作業計画書]
-    WP --> TE[task-executor タスク実行]
-    Direct --> QF[quality-fixer 品質チェック]
+    TD --> WP["work-planner 作業計画書"]
+    WP --> TE["task-executor タスク実行"]
+    Direct --> QF["quality-fixer 品質チェック"]
     TE --> QF
     QF --> End[完了]
     


### PR DESCRIPTION
- Add double quotes around node labels containing hyphens in mermaid diagrams
- Fix GitHub mermaid parser lexical errors for agent names
- Apply to both Japanese and English use-cases.md files

🤖 Generated with [Claude Code](https://claude.ai/code)