### PR TITLE
fix: wrap Start node labels with quotes to handle forward slash

### DIFF
--- a/docs/guides/en/use-cases.md
+++ b/docs/guides/en/use-cases.md
@@ -26,7 +26,7 @@ graph LR
 
 ```mermaid
 graph TD
-    Start[/implement requirements] --> RA["requirement-analyzer scale detection"]
+    Start["/implement requirements"] --> RA["requirement-analyzer scale detection"]
     RA -->|Small| Direct[Direct implementation]
     RA -->|Medium| TD["technical-designer Design Doc"]
     RA -->|Large| PRD["prd-creator PRD"]

--- a/docs/guides/ja/use-cases.md
+++ b/docs/guides/ja/use-cases.md
@@ -26,7 +26,7 @@ graph LR
 
 ```mermaid
 graph TD
-    Start[/implement 要件] --> RA["requirement-analyzer 規模判定"]
+    Start["/implement 要件"] --> RA["requirement-analyzer 規模判定"]
     RA -->|小規模| Direct[直接実装]
     RA -->|中規模| TD["technical-designer Design Doc作成"]
     RA -->|大規模| PRD["prd-creator PRD作成"]


### PR DESCRIPTION
- Add double quotes around Start node labels containing forward slash
- Apply to both Japanese and English use-cases.md files
- Testing if slash is causing the GitHub mermaid parser error

🤖 Generated with [Claude Code](https://claude.ai/code)