### PR TITLE
docs: clarify main AI verification step between acceptance-test-gener…

### DIFF
--- a/docs/guides/en/sub-agents.md
+++ b/docs/guides/en/sub-agents.md
@@ -180,14 +180,16 @@ According to scale determination:
 2. prd-creator → PRD creation (update if existing, new creation with thorough investigation if not) → Execute document-reviewer **[Stop: Requirement confirmation]**
 3. technical-designer → ADR creation (if needed) → Execute document-reviewer **[Stop: Technical direction decision]**
 4. technical-designer → Design Doc creation → Execute document-reviewer **[Stop: Design content confirmation]**
-5. acceptance-test-generator → Integration and E2E test skeleton generation (from Design Doc ACs, separately)
+5. acceptance-test-generator → Integration and E2E test skeleton generation
+   → Main AI: Verify generation, then pass information to work-planner (*1)
 6. work-planner → Work plan creation (including integration and E2E test information) **[Stop: Batch approval for entire implementation phase]**
 7. **Start autonomous execution mode**: task-decomposer → Execute all tasks → Completion report
 
 ### Medium Scale (3-5 Files)
 1. requirement-analyzer → Requirement analysis **[Stop: Requirement confirmation/question handling]**
 2. technical-designer → Design Doc creation → Execute document-reviewer **[Stop: Technical direction decision]**
-3. acceptance-test-generator → Integration and E2E test skeleton generation (from Design Doc ACs, separately)
+3. acceptance-test-generator → Integration and E2E test skeleton generation
+   → Main AI: Verify generation, then pass information to work-planner (*1)
 4. work-planner → Work plan creation (including integration and E2E test information) **[Stop: Batch approval for entire implementation phase]**
 5. **Start autonomous execution mode**: task-decomposer → Execute all tasks → Completion report
 
@@ -260,13 +262,23 @@ Stop autonomous execution and escalate to user in the following cases:
 2. **Information Bridging**: Data conversion and transmission between subagents
    - Convert each subagent's output to next subagent's input format
    - **Always pass deliverables from previous process to next agent**
-   - After acceptance-test-generator execution, pass to work-planner:
-     "Integration test file: [path] → Create and execute simultaneously with each phase implementation
-      E2E test file: [path] → Execute only in final phase
-      Important: Integration tests with implementation, E2E after all implementations"
    - Extract necessary information from structured responses
    - Compose commit messages from changeSummary → **Execute git commit with Bash**
    - Explicitly integrate initial and additional requirements when requirements change
+
+   #### *1 acceptance-test-generator → work-planner
+
+   **Purpose**: Prepare information for work-planner to incorporate into work plan
+
+   **Main AI verification items**:
+   - Verify integration test file path retrieval and existence
+   - Verify E2E test file path retrieval and existence
+
+   **Pass to work-planner**:
+   - Integration test file: [path] (create and execute simultaneously with each phase implementation)
+   - E2E test file: [path] (execute only in final phase)
+
+   **On error**: Escalate to user if files are not generated
 3. **Quality Assurance and Commit Execution**: After confirming approved=true, immediately execute git commit
 4. **Autonomous Execution Mode Management**: Start/stop autonomous execution after approval, escalation decisions
 5. **ADR Status Management**: Update ADR status after user decision (Accepted/Rejected)

--- a/docs/guides/ja/sub-agents.md
+++ b/docs/guides/ja/sub-agents.md
@@ -162,15 +162,17 @@ requirement-analyzerは「完全自己完結」の原則に従い、要件変更
 2. prd-creator → PRD作成（既存あれば更新、なければ徹底調査で新規作成） → document-reviewer実行 **[停止: 要件確認]**
 3. technical-designer → ADR作成（必要な場合） → document-reviewer実行 **[停止: 技術方針決定]**
 4. technical-designer → Design Doc作成 → document-reviewer実行 **[停止: 設計内容確認]**
-5. acceptance-test-generator → 統合テスト・E2Eテストスケルトン生成（Design DocのACから別々に）
-6. work-planner → 作業計画書作成（統合テスト・E2Eテスト情報を含めて） **[停止: 実装フェーズ全体の一括承認]**
+5. acceptance-test-generator → 統合テスト・E2Eテストスケルトン生成
+   → メインAI: 生成確認後、work-plannerへ情報引き渡し（※1）
+6. work-planner → 作業計画書作成（統合テスト・E2Eテスト情報を含む） **[停止: 実装フェーズ全体の一括承認]**
 7. **自律実行モード開始**: task-decomposer → 全タスク実行 → 完了報告
 
 ### 中規模（3-5ファイル）
 1. requirement-analyzer → 要件分析 **[停止: 要件確認・質問事項対応]**
 2. technical-designer → Design Doc作成 → document-reviewer実行 **[停止: 技術方針決定]**
-3. acceptance-test-generator → 統合テスト・E2Eテストスケルトン生成（Design DocのACから別々に）
-4. work-planner → 作業計画書作成（統合テスト・E2Eテスト情報を含めて） **[停止: 実装フェーズ全体の一括承認]**
+3. acceptance-test-generator → 統合テスト・E2Eテストスケルトン生成
+   → メインAI: 生成確認後、work-plannerへ情報引き渡し（※1）
+4. work-planner → 作業計画書作成（統合テスト・E2Eテスト情報を含む） **[停止: 実装フェーズ全体の一括承認]**
 5. **自律実行モード開始**: task-decomposer → 全タスク実行 → 完了報告
 
 ### 小規模（1-2ファイル）
@@ -242,13 +244,23 @@ graph TD
 2. **情報の橋渡し**: サブエージェント間のデータ変換と伝達
    - 各Sub-agentの出力を次のSub-agentの入力形式に変換
    - **前工程の成果物を必ず次のエージェントに伝達**
-   - acceptance-test-generator実行後はwork-plannerに以下を伝達：
-     「統合テストファイル: [パス] → 各Phase実装時に同時作成・実行
-      E2Eテストファイル: [パス] → 最終Phaseでのみ実行
-      重要: 統合テストは実装と同時、E2Eは全実装後」
    - 構造化レスポンスから必要な情報を抽出
    - changeSummaryからコミットメッセージ構成→**Bashでgit commit実行**
    - 要件変更時は初回要件と追加要件を明示的に統合
+
+   #### ※1 acceptance-test-generator → work-planner
+
+   **目的**: work-plannerが作業計画書に組み込むための情報を準備
+
+   **メインAIの確認項目**:
+   - 統合テストファイルのパス取得・存在確認
+   - E2Eテストファイルのパス取得・存在確認
+
+   **work-plannerへの伝達**:
+   - 統合テストファイル: [パス]（各Phase実装時に同時作成・実行）
+   - E2Eテストファイル: [パス]（最終Phaseでのみ実行）
+
+   **異常時**: ファイル未生成の場合はユーザーにエスカレーション
 3. **品質保証とコミット実行**: approved=true確認後、即座にgit commit実行  
 4. **自律実行モード管理**: 承認後の自律実行開始・停止・エスカレーション判断
 5. **ADRステータス管理**: ユーザー判断後のADRステータス更新（Accepted/Rejected）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-coding-project-boilerplate",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-coding-project-boilerplate",
-      "version": "1.7.11",
+      "version": "1.7.12",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-project-boilerplate",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "TypeScript project boilerplate optimized for Claude Code development with comprehensive development rules, architecture patterns, and quality assurance tools",
   "main": "dist/index.js",
   "keywords": [


### PR DESCRIPTION
…ator and work-planner

Add explicit verification step for main AI orchestrator to confirm test skeleton generation before passing information to work-planner. This prevents the main AI from skipping acceptance-test-generator execution.

Changes:
- Add main AI verification step in workflow descriptions (large/medium scale)
- Add detailed verification checklist in "Information Bridge" section
- Specify verification items: test file path retrieval and existence confirmation
- Define error handling: escalate to user if files are not generated

This ensures the main AI recognizes acceptance-test-generator as a mandatory step in the workflow, improving execution accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)