### PR TITLE
fix: exclude generated Claude Code files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,9 @@ tmp/
 
 # OS files
 .DS_Store
+
+# Claude Code generated/local files
+.claude/settings.local.json
+.claude/agents/
+.claude/commands/
+.claude/skills/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ai-project",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "packageManager": "npm@10.8.2",
   "description": "TypeScript project boilerplate optimized for Claude Code development with comprehensive development rules, architecture patterns, and quality assurance tools",
   "keywords": [


### PR DESCRIPTION
## Summary
- Exclude language-generated directories (`.claude/agents/`, `.claude/commands/`, `.claude/skills/`) from npm package
- Exclude local settings file (`.claude/settings.local.json`)
- Source files (`-ja/`, `-en/` variants) remain included for proper language selection after installation

## Test plan
- [x] Run `npm pack --dry-run` and verify generated directories are excluded
- [x] Verify `-ja/` and `-en/` directories are still included

🤖 Generated with [Claude Code](https://claude.com/claude-code)