### PR TITLE
fix: escape slash in mermaid diagram node label

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Generate PRD and Design Docs from existing code:
 ```mermaid
 graph TB
     subgraph Phase1[Phase 1: PRD Generation]
-        CMD[/reverse-engineer] --> SD1[scope-discoverer]
+        CMD["/reverse-engineer"] --> SD1[scope-discoverer]
         SD1 --> PRD[prd-creator]
         PRD --> CV1[code-verifier]
         CV1 --> DR1[document-reviewer]


### PR DESCRIPTION
## Summary
- Fixed Mermaid diagram rendering error in README
- The `/reverse-engineer` command label was causing a lexical error due to unescaped slash
- Wrapped the label in quotes to fix the issue

## Test plan
- [ ] Verify Mermaid diagram renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)