### PR TITLE
feat: add Bash tool to 11 agents requiring shell execution

### DIFF
--- a/.claude/agents-en/code-reviewer.md
+++ b/.claude/agents-en/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Validates Design Doc compliance and implementation completeness from third-party perspective. Use PROACTIVELY after implementation completes or when "review/implementation check/compliance" is mentioned. Provides acceptance criteria validation and quality reports.
-tools: Read, Grep, Glob, LS
+tools: Read, Grep, Glob, LS, Bash
 skills: coding-standards, typescript-rules, typescript-testing, project-context, technical-spec
 ---
 

--- a/.claude/agents-en/code-verifier.md
+++ b/.claude/agents-en/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: Validates consistency between PRD/Design Doc and code implementation. Use PROACTIVELY after implementation completes, or when "document consistency/implementation gap/as specified" is mentioned. Uses multi-source evidence matching to identify discrepancies.
-tools: Read, Grep, Glob, LS, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, TodoWrite
 skills: documentation-criteria, coding-standards, typescript-rules
 ---
 

--- a/.claude/agents-en/document-reviewer.md
+++ b/.claude/agents-en/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: Reviews document consistency and completeness, providing approval decisions. Use PROACTIVELY after PRD/Design Doc/work plan creation, or when "document review/approval/check" is mentioned. Detects contradictions and rule violations with improvement suggestions.
-tools: Read, Grep, Glob, LS, TodoWrite, WebSearch
+tools: Read, Grep, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, technical-spec, project-context, typescript-rules
 ---
 

--- a/.claude/agents-en/integration-test-reviewer.md
+++ b/.claude/agents-en/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: Verifies consistency between test skeleton comments and implementation code. Use PROACTIVELY after test implementation completes, or when "test review/skeleton verification" is mentioned. Returns quality reports with failing items and fix instructions.
-tools: Read, Grep, Glob, LS
+tools: Read, Grep, Glob, LS, Bash
 skills: integration-e2e-testing, typescript-testing, project-context
 ---
 

--- a/.claude/agents-en/investigator.md
+++ b/.claude/agents-en/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: Comprehensively collects problem-related information and creates evidence matrix. Use PROACTIVELY when bug/error/issue/defect/not working/strange behavior is reported. Reports only observations without proposing solutions.
-tools: Read, Grep, Glob, LS, WebSearch, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, WebSearch, TodoWrite
 skills: project-context, technical-spec, coding-standards
 ---
 

--- a/.claude/agents-en/prd-creator.md
+++ b/.claude/agents-en/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: Creates PRD and structures business requirements. Use when new feature/project starts, or when "PRD/requirements definition/user story/what to build" is mentioned. Defines user value and success metrics.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, project-context, technical-spec
 ---
 

--- a/.claude/agents-en/requirement-analyzer.md
+++ b/.claude/agents-en/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: Performs requirements analysis and work scale determination. Use PROACTIVELY when new feature requests or change requests are received, or when "requirements/scope/where to start" is mentioned. Extracts user requirement essence and proposes development approaches.
-tools: Read, Grep, Glob, LS, TodoWrite, WebSearch
+tools: Read, Grep, Glob, LS, Bash, TodoWrite, WebSearch
 skills: project-context, documentation-criteria, technical-spec, coding-standards
 ---
 

--- a/.claude/agents-en/scope-discoverer.md
+++ b/.claude/agents-en/scope-discoverer.md
@@ -1,7 +1,7 @@
 ---
 name: scope-discoverer
 description: Discovers PRD/Design Doc scope from existing codebase. Use when existing code documentation is needed, or when "reverse engineering/existing code analysis/scope discovery" is mentioned. Identifies targets through multi-source discovery.
-tools: Read, Grep, Glob, LS, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, TodoWrite
 skills: documentation-criteria, coding-standards, technical-spec
 ---
 

--- a/.claude/agents-en/technical-designer-frontend.md
+++ b/.claude/agents-en/technical-designer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer-frontend
 description: Creates frontend ADR and Design Docs to evaluate React technical choices. Use when frontend PRD is complete and technical design is needed, or when "frontend design/React design/UI design/component design" is mentioned.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, frontend/technical-spec, frontend/typescript-rules, coding-standards, project-context, implementation-approach
 ---
 

--- a/.claude/agents-en/technical-designer.md
+++ b/.claude/agents-en/technical-designer.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer
 description: Creates ADR and Design Docs to evaluate technical choices. Use when PRD is complete and technical design is needed, or when "design/architecture/technical selection/ADR" is mentioned. Defines implementation approach.
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, technical-spec, typescript-rules, coding-standards, project-context, implementation-approach
 ---
 

--- a/.claude/agents-en/verifier.md
+++ b/.claude/agents-en/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: Critically evaluates investigation results and identifies oversights. Use when investigator completes investigation, or when "verify/really/confirm/oversight/other possibilities" is mentioned. Uses ACH and Devil's Advocate to verify validity and derive conclusions.
-tools: Read, Grep, Glob, LS, WebSearch, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, WebSearch, TodoWrite
 skills: project-context, technical-spec, coding-standards
 ---
 

--- a/.claude/agents-ja/code-reviewer.md
+++ b/.claude/agents-ja/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Design Doc準拠と実装完全性を第三者視点で検証。Use PROACTIVELY after implementation completes または「レビュー/review/実装チェック/準拠確認」が言及された時。受入条件照合、実装漏れ検出、品質レポートを提供。
-tools: Read, Grep, Glob, LS
+tools: Read, Grep, Glob, LS, Bash
 skills: coding-standards, typescript-rules, typescript-testing, project-context, technical-spec
 ---
 

--- a/.claude/agents-ja/code-verifier.md
+++ b/.claude/agents-ja/code-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: code-verifier
 description: PRD/Design Docとコード実装間の整合性を検証。Use PROACTIVELY after 実装完了時、または「ドキュメント整合性/実装漏れ/仕様通り」が言及された時。multi-source evidence matchingで不整合を特定。
-tools: Read, Grep, Glob, LS, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, TodoWrite
 skills: documentation-criteria, coding-standards, typescript-rules
 ---
 

--- a/.claude/agents-ja/document-reviewer.md
+++ b/.claude/agents-ja/document-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: document-reviewer
 description: ドキュメントの整合性と完成度をレビューし承認判定を提供。Use PROACTIVELY after PRD/Design Doc/作業計画書作成後、または「ドキュメントレビュー/承認/チェック」が言及された時。矛盾・ルール違反を検出し改善提案。
-tools: Read, Grep, Glob, LS, TodoWrite, WebSearch
+tools: Read, Grep, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, technical-spec, project-context, typescript-rules
 ---
 

--- a/.claude/agents-ja/integration-test-reviewer.md
+++ b/.claude/agents-ja/integration-test-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: integration-test-reviewer
 description: テストファイルのスケルトンコメントと実装コードの整合性を検証。Use PROACTIVELY after テスト実装完了時、または「テストレビュー/test review/スケルトン検証」が言及された時。不合格項目と修正指示を含む品質レポートを返却。
-tools: Read, Grep, Glob, LS
+tools: Read, Grep, Glob, LS, Bash
 skills: integration-e2e-testing, typescript-testing, project-context
 ---
 

--- a/.claude/agents-ja/investigator.md
+++ b/.claude/agents-ja/investigator.md
@@ -1,7 +1,7 @@
 ---
 name: investigator
 description: 問題に関連する情報を網羅的に収集し証拠マトリクスを作成。Use PROACTIVELY when バグ/エラー/問題/不具合/動かない/おかしい が報告された時。解決策は考えず観察結果のみを報告。
-tools: Read, Grep, Glob, LS, WebSearch, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, WebSearch, TodoWrite
 skills: project-context, technical-spec, coding-standards
 ---
 

--- a/.claude/agents-ja/prd-creator.md
+++ b/.claude/agents-ja/prd-creator.md
@@ -1,7 +1,7 @@
 ---
 name: prd-creator
 description: PRDを作成しビジネス要件を構造化。Use when 新機能/プロジェクト開始時、または「PRD/要件定義/ユーザーストーリー/何を作る」が言及された時。ユーザー価値と成功指標を定義。
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, project-context, technical-spec
 ---
 

--- a/.claude/agents-ja/requirement-analyzer.md
+++ b/.claude/agents-ja/requirement-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: requirement-analyzer
 description: 要件分析と作業規模判定を実行。Use PROACTIVELY when 新機能リクエストや変更要求を受けた時、または「要件/requirement/規模/スコープ/何から始める」が言及された時。ユーザー要求の本質を抽出し、適切な開発アプローチを提案。
-tools: Read, Grep, Glob, LS, TodoWrite, WebSearch
+tools: Read, Grep, Glob, LS, Bash, TodoWrite, WebSearch
 skills: project-context, documentation-criteria, technical-spec, coding-standards
 ---
 

--- a/.claude/agents-ja/scope-discoverer.md
+++ b/.claude/agents-ja/scope-discoverer.md
@@ -1,7 +1,7 @@
 ---
 name: scope-discoverer
 description: 既存コードベースからPRD/Design Docのスコープを導出。Use when 既存コードのドキュメント化が必要な時、または「リバースエンジニアリング/既存コード分析/スコープ特定」が言及された時。マルチソース探索で対象を特定。
-tools: Read, Grep, Glob, LS, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, TodoWrite
 skills: documentation-criteria, coding-standards, technical-spec
 ---
 

--- a/.claude/agents-ja/technical-designer-frontend.md
+++ b/.claude/agents-ja/technical-designer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer-frontend
 description: フロントエンドADRとDesign Docを作成しReact技術選択肢を評価。Use when フロントエンドPRD完成後に技術設計が必要な時、または「フロントエンド設計/React設計/UI設計/コンポーネント設計」が言及された時。
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, frontend/technical-spec, frontend/typescript-rules, coding-standards, project-context, implementation-approach
 ---
 

--- a/.claude/agents-ja/technical-designer.md
+++ b/.claude/agents-ja/technical-designer.md
@@ -1,7 +1,7 @@
 ---
 name: technical-designer
 description: ADRとDesign Docを作成し技術的選択肢を評価。Use when PRD完成後に技術設計が必要な時、または「設計/design/アーキテクチャ/技術選定/ADR」が言及された時。実装アプローチを定義。
-tools: Read, Write, Edit, MultiEdit, Glob, LS, TodoWrite, WebSearch
+tools: Read, Write, Edit, MultiEdit, Glob, LS, Bash, TodoWrite, WebSearch
 skills: documentation-criteria, technical-spec, typescript-rules, coding-standards, project-context, implementation-approach
 ---
 

--- a/.claude/agents-ja/verifier.md
+++ b/.claude/agents-ja/verifier.md
@@ -1,7 +1,7 @@
 ---
 name: verifier
 description: 調査結果を批判的に評価し見落としを探す。Use when investigatorの調査完了後、または「検証/本当に/確認/見落とし/他の可能性」が言及された時。ACH・Devil's Advocate手法で妥当性を検証し結論を導出。
-tools: Read, Grep, Glob, LS, WebSearch, TodoWrite
+tools: Read, Grep, Glob, LS, Bash, WebSearch, TodoWrite
 skills: project-context, technical-spec, coding-standards
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ai-project",
-  "version": "1.14.14",
+  "version": "1.14.15",
   "packageManager": "npm@10.8.2",
   "description": "TypeScript boilerplate with skills and sub-agents for Claude Code. Prevents context exhaustion through role-based task splitting.",
   "keywords": [


### PR DESCRIPTION
## Summary

- Added `Bash` to the `tools` frontmatter of 11 agents (both `agents-ja` and `agents-en`) that were missing shell command access
- Bumped version from 1.14.14 to 1.14.15

### Agents with explicit command needs (date, git diff)
- investigator, verifier, requirement-analyzer, prd-creator, technical-designer, document-reviewer

### Agents that benefit from Bash during work process (running tests, checking dependencies, git history)
- scope-discoverer, code-reviewer, code-verifier, integration-test-reviewer, technical-designer-frontend

## Test plan
- [x] Verify each updated agent file has `Bash` in its tools frontmatter
- [x] Confirm no unintended changes to agent behavior or other frontmatter fields
- [x] Version bump applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)