### PR TITLE
chore: bump CI action pins to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set timezone
       run: |
@@ -24,7 +24,7 @@ jobs:
         echo "TZ=Asia/Tokyo" >> $GITHUB_ENV
 
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ matrix.node-version }}
+        # Lock file is intentionally not committed (CI uses `npm install`),
+        # so disable setup-node's auto package-manager caching to avoid
+        # "Dependencies lock file is not found" failures.
+        package-manager-cache: false
 
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
## Summary

Updates the SHA-pinned GitHub Actions in `.github/workflows/ci.yml` to their latest releases. The previous pins were two major versions behind.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `34e1148…` v4.3.1 | `df4cb1c…` v6.0.3 |
| `actions/setup-node` | `49933ea…` v4.4.0 | `48b55a0…` v6.4.0 |

## Verification

- Both new SHAs were verified against the corresponding release tags via the GitHub API (the `checkout` annotated tag was dereferenced to its commit SHA).
- The CI runs on GitHub-hosted `ubuntu-latest`, so the Node 24 runtime required by `checkout` v5+ is satisfied.
- No changes to the `npm install` / lint / format / build steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)