### PR TITLE
docs(readme): list llm-friendly-context in the Applied Skills table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -183,6 +183,7 @@ Claude Codeで利用できる主要なコマンド
 | `frontend-typescript-rules` | Reactコンポーネント設計、Props駆動パターン |
 | `frontend-typescript-testing` | React Testing Library、MSW、Playwright E2E（fixture / service-integrationパターン） |
 | `frontend-technical-spec` | Reactアーキテクチャ、環境設定、データフロー |
+| `llm-friendly-context` | LLM向け出力（プロンプト、ハンドオフ、生成物）の明確さ |
 | `project-context` | AIの実行精度のためのプロジェクト前提情報（`/project-inject`で設定） |
 
 👉 [スキルの仕組みについて（Claude Code docs）](https://code.claude.com/docs/ja/skills)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ This boilerplate provides the principles used in agentic implementation workflow
 | `frontend-typescript-rules` | React component design, Props-driven patterns |
 | `frontend-typescript-testing` | React Testing Library, MSW, Playwright E2E (fixture and service-integration patterns) |
 | `frontend-technical-spec` | React architecture, environment, data flow |
+| `llm-friendly-context` | Clarity of LLM-facing output — prompts, handoffs, and generated artifacts |
 | `project-context` | Project-specific prerequisites for AI accuracy (set via `/project-inject`) |
 
 👉 [Learn how Skills work (Claude Code docs)](https://code.claude.com/docs/en/skills)


### PR DESCRIPTION
## Summary

The `llm-friendly-context` skill — added in #180 (v1.25.0) — was missing from the **Applied Skills** table in both READMEs. This adds it.

It governs the clarity of LLM-facing output (prompts, handoffs, and generated artifacts). Producing artifacts and adding context to the repo is an applied context-engineering activity that users do in everyday work, not an internal/meta concern — so it belongs alongside the other applied skills in the table.

## Changes

- `README.md` — added `llm-friendly-context` row to the Applied Skills table
- `README.ja.md` — same, kept in sync (en/ja)

Placed right before `project-context` (the project-specific, user-configured entry stays last).

## Notes

- Docs-only change; one row added per file.
- pre-commit `check:skills-index` passes (all 28 skills consistent across en/ja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)