### PR TITLE
Align the npm package description with current positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-ai-project",
   "version": "1.27.2",
   "packageManager": "npm@10.8.2",
-  "description": "TypeScript boilerplate with skills and sub-agents for Claude Code. Prevents context exhaustion through role-based task splitting.",
+  "description": "Evidence-driven Claude Code workflows for TypeScript projects, from design and implementation through review and quality checks.",
   "keywords": [
     "typescript",
     "boilerplate",


### PR DESCRIPTION
## Summary

- align the npm package description with the current README positioning
- remove the obsolete context-exhaustion claim
- leave the version and release contents unchanged so this can be merged with a later update

## Verification

- `npm pkg get name version description`
- commit hook: `npm run check:skills-index`
- pre-push hook: `npm run check` and `npm run build`