### PR TITLE
Remove em dashes from README titles

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# AI Coding Project Boilerplate — Claude Codeスターターキット
+# AI Coding Project Boilerplate：Claude Codeスターターキット
 
 *他の言語で読む: [English](README.md) | [简体中文](README.zh-CN.md)*
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Coding Project Boilerplate — A Starter Kit for Claude Code
+# AI Coding Project Boilerplate: A Starter Kit for Claude Code
 
 *Read this in other languages: [日本語](README.ja.md) | [简体中文](README.zh-CN.md)*
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# AI 编程项目模板 — Claude Code 入门套件
+# AI 编程项目模板：Claude Code 入门套件
 
 *其他语言版本：[English](README.md) | [日本語](README.ja.md)*
 


### PR DESCRIPTION
## Summary

- replace em dashes in the English, Japanese, and Simplified Chinese README titles with language-appropriate colons

## Verification

- `git diff --check`
- confirmed that `README.md`, `README.ja.md`, and `README.zh-CN.md` contain no em dashes
