### PR TITLE
chore: normalize npm package metadata for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shinpr/ai-coding-project-boilerplate.git"
+    "url": "git+https://github.com/shinpr/ai-coding-project-boilerplate.git"
   },
   "bin": {
-    "create-ai-project": "./bin/create-project.js"
+    "create-ai-project": "bin/create-project.js"
   },
   "scripts": {
     "build": "tsc && tsc-alias",


### PR DESCRIPTION
## Summary

- Normalize the repository URL to npm's canonical git+https form.
- Normalize the CLI bin path by removing the leading ./.
- Keep the change limited to package.json.

## Verification

- npm pkg fix reproduces the same normalization on an isolated copy.
- npm pack --dry-run --ignore-scripts includes package.json and bin/create-project.js.
- Pre-commit check-skills-index passed.
- Pre-push npm run check and npm run build passed.