### PR TITLE
fix: keep published setup output clean

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -24,6 +24,7 @@ knip.json
 .DS_Store
 
 # Claude Code generated/local files
+CLAUDE.md
 .claude/settings.local.json
 .claude/agents/
 .claude/commands/

--- a/scripts/post-setup.js
+++ b/scripts/post-setup.js
@@ -90,11 +90,11 @@ function showNextSteps() {
  */
 function main() {
   try {
-    // Initialize git repository
-    initGit()
-
     // Clean up setup-specific files
     cleanupFiles()
+
+    // Initialize git repository after the generated project is complete
+    initGit()
 
     // Show next steps
     showNextSteps()

--- a/scripts/setup-project.js
+++ b/scripts/setup-project.js
@@ -192,13 +192,7 @@ async function setupProject() {
     console.log('📝 Creating .gitignore with language-specific exclusions...')
     createGitignore(targetRoot)
 
-    console.log('🔧 Running post-setup tasks...')
-    const postSetupScript = path.join(sourceRoot, 'scripts', 'post-setup.js')
-    if (fs.existsSync(postSetupScript)) {
-      execSync(`node ${postSetupScript}`, { stdio: 'inherit', cwd: targetRoot })
-    }
-
-    // Create .create-ai-project.json manifest
+    // Create .create-ai-project.json manifest before the initial commit
     const packageJson = JSON.parse(fs.readFileSync(path.join(sourceRoot, 'package.json'), 'utf8'))
     const manifest = {
       version: packageJson.version,
@@ -211,6 +205,12 @@ async function setupProject() {
       `${JSON.stringify(manifest, null, 2)}\n`
     )
     console.log('📋 Created .create-ai-project.json manifest.')
+
+    console.log('🔧 Running post-setup tasks...')
+    const postSetupScript = path.join(sourceRoot, 'scripts', 'post-setup.js')
+    if (fs.existsSync(postSetupScript)) {
+      execSync(`node ${postSetupScript}`, { stdio: 'inherit', cwd: targetRoot })
+    }
 
     console.log('✅ Project setup completed!')
   } catch (error) {


### PR DESCRIPTION
## Summary

- exclude the generated local CLAUDE.md from npm packages
- create .create-ai-project.json before the generated repository initial commit
- remove setup-only files before the generated repository initial commit

## Context

The npm 2.0.0 artifact was published from a working tree containing these fixes. This PR makes the repository source match that published artifact.

Before the fixes, a generated project immediately contained a deleted scripts/post-setup.js and an untracked .create-ai-project.json.

## Verification

- Node 24.15.0 and pnpm 11.25.0
- pnpm run check:skills-index
- pnpm run check:code
- packed CLI smoke test with zh-CN
- confirmed CLAUDE.md is absent from the npm tarball
- confirmed the generated repository has a clean Git status

## Follow-up

After merge, move the v2.0.0 tag from b033b19 to the merge commit so the Git tag matches the published npm artifact.